### PR TITLE
Updated shape default props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v0.5.0
+- shape with no keys which have defaults defined returns `undefined` for shape default prop
+
+v0.4.0
+- revert addition of `depricated` key
+
 v0.3.0
 
 - adds a `deprecated` key to prop type definitions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ v0.5.0
 - shape with no keys which have defaults defined returns `undefined` for shape default prop
 
 v0.4.0
-- revert addition of `depricated` key
+- revert addition of `deprecated` key
 
 v0.3.0
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# prop-types-docs [![CircleCI](https://circleci.com/gh/farism/prop-types-docs.svg?style=svg)](https://circleci.com/gh/farism/prop-types-docs)
+# prop-types-docs [![CircleCI](https://circleci.com/gh/procore/prop-types-docs.svg?style=svg)](https://circleci.com/gh/procore/prop-types-docs)
 
 ### Document your prop types!
 
-### [API Documentation](https://github.com/farism/prop-types-docs/blob/master/API.md)
+### [API Documentation](https://github.com/procore/prop-types-docs/blob/master/API.md)
 
 ### Installation
 

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -388,6 +388,44 @@ describe('withPropDocs', () => {
       })
     })
 
+    it('sets a default shape value of undefined', () => {
+      const Cmp = ({ children }) => children
+
+      withPropDocs({
+        name: 'Cmp2',
+        props: {
+          shape: shape({
+            string: {
+              type: string,
+              // default: 'hello world'
+            }
+          }),
+        }
+      })(Cmp)
+
+      expect(Cmp.defaultProps.shape).toEqual(undefined)
+    })
+
+    it('sets a default shape value if passed one', () => {
+      const Cmp = ({ children }) => children
+
+      withPropDocs({
+        name: 'Cmp2',
+        props: {
+          shape: shape({
+            string: {
+              type: string,
+              default: 'hello world'
+            }
+          }),
+        },
+      })(Cmp)
+
+      expect(Cmp.defaultProps.shape).toEqual({
+        string: 'hello world'
+      })
+    })
+
     it('skips undefined default props', () => {
       const Cmp = ({ children }) => children
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prop-types-docs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "main": "build/index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/farism/prop-types-docs.git"
+    "url": "git+https://github.com/procore/prop-types-docs.git"
   },
   "peerDependencies": {
     "prop-types": "^15.6.0"

--- a/src/index.js
+++ b/src/index.js
@@ -11,16 +11,21 @@ const getComponentPropTypes = props =>
     {},
   )
 
-const getComponentDefaultProps = props =>
-  Object.keys(props).reduce((acc, key) => {
-    const defaultProp =
-      props[key].type.name === 'shape'
-        ? getComponentDefaultProps(props[key].props)
-        : props[key].default
+
+const getComponentDefaultProps = (props) => {
+  return Object.keys(props).reduce((acc, key) => {
+    let defaultProp = {};
+    if (props[key].type.name === 'shape') {
+      const shapeDefaults = getComponentDefaultProps(props[key].props);
+      defaultProp = Object.keys(shapeDefaults).length > 0 ? shapeDefaults : undefined;
+    } else {
+      defaultProp = props[key].default;
+    }
     return defaultProp === undefined
       ? acc
       : Object.assign({}, acc, { [key]: defaultProp })
   }, {})
+}
 
 const withPropDocs = ({
   name = '',
@@ -125,15 +130,16 @@ const objectOf = type => ({
   req: () => PropTypes.objectOf(type.fn()).isRequired,
 })
 
-const shape = props => ({
-  props,
-  type: {
-    name: 'shape',
-    fn: () => PropTypes.shape(getComponentPropTypes(props)),
-    req: () => PropTypes.shape(getComponentPropTypes(props)).isRequired,
-    default: {},
-  },
-})
+const shape = (props) => {
+  return ({
+    props,
+    type: {
+      name: 'shape',
+      fn: () => PropTypes.shape(getComponentPropTypes(props)),
+      req: () => PropTypes.shape(getComponentPropTypes(props)).isRequired
+    }
+  });
+}
 
 module.exports = {
   array,


### PR DESCRIPTION
Change log
- shape with no keys which have defaults defined returns `undefined` for shape default prop
- shape with keys which have defaults should continue to return defined shape defaults
- updated circle and github links to point to procore org